### PR TITLE
Fix missing "data" method when accesing a Git::Submodule

### DIFF
--- a/lib/gitlab_git/blob.rb
+++ b/lib/gitlab_git/blob.rb
@@ -13,7 +13,7 @@ module Gitlab
       end
 
       def data
-        if raw_blob
+        if raw_blob and raw_blob.respond_to?('data')
           raw_blob.data
         else
           nil


### PR DESCRIPTION
When comparing two commits, which lists differences involving a submodule, a "missing 'data' method on Grit::Submodule" error is thrown.

This fixes that use case.
