### PR TITLE
Try to fix default branch selection

### DIFF
--- a/lib/gitlab_git/repository.rb
+++ b/lib/gitlab_git/repository.rb
@@ -28,8 +28,8 @@ module Gitlab
       # compatibility
       alias_method :repo, :raw
 
-      def initialize(path_with_namespace, root_ref = 'master')
-        @root_ref = root_ref || "master"
+      def initialize(path_with_namespace, root_ref)
+        @root_ref = root_ref || raw.head.name
         @path_with_namespace = path_with_namespace
 
         # Init grit repo object


### PR DESCRIPTION
Hi!

With this change the default branch of a repository is selected dynamically. The idea comes from the grit api doc:
http://www.ruby-doc.org/gems/docs/g/grit-2.5.0/Grit/Repo.html#method-i-head
http://www.ruby-doc.org/gems/docs/g/grit-2.5.0/Grit/Head.html

I'm not a ruby programmer and I know ruby only a very basic level so maybe I'm doing it wrong, but it works for me. Please review and correct if it's required. Thanks!

Related to gitlabhq/gitlabhq#3693, gitlabhq/gitlabhq#4347, gitlabhq/gitlabhq#4307, gitlabhq/gitlabhq#4302, gitlabhq/gitlabhq#4137, ...
