### PR TITLE
Adds Commit.quick_diffs wrapper method.

### DIFF
--- a/lib/gitlab_git/commit.rb
+++ b/lib/gitlab_git/commit.rb
@@ -91,6 +91,10 @@ module Gitlab
         raw_commit.diffs.map { |diff| Gitlab::Git::Diff.new(diff) }
       end
 
+      def quick_diffs
+        raw_commit.quick_diffs.map { |diff| Gitlab::Git::Diff.new(diff) }
+      end
+
       def parents
         raw_commit.parents
       end


### PR DESCRIPTION
Just calls the grit equivalent.

This goes with the related change to the gitlabhq/grit repo: https://github.com/gitlabhq/grit/pull/30
