### PR TITLE
Fixed JSON encoding error

### DIFF
--- a/lib/gitlab_git/log_parser.rb
+++ b/lib/gitlab_git/log_parser.rb
@@ -10,8 +10,8 @@ module Gitlab
 
         log.each_slice(5) do |slice|
           entry = {}
-          entry[:author_name] = slice[0]
-          entry[:author_email] = slice[1]
+          entry[:author_name] = slice[0].force_encoding('UTF-8')
+          entry[:author_email] = slice[1].force_encoding('UTF-8')
           entry[:date] = slice[2]
 
           if slice[4]


### PR DESCRIPTION
When git's log contain UTF8 code (e.g. Chinese text), `to_json` conver it to wrong string with `"���"`

![qq20130826-1](https://f.cloud.github.com/assets/1243254/1023611/320d06e2-0df9-11e3-8054-9a12e7314bce.png)

With this fix, encoding will work correctly.
