### PR TITLE
fixed a bug that caused non-empty projects to appear empty in some cases

### DIFF
--- a/lib/gitlab_git/repository.rb
+++ b/lib/gitlab_git/repository.rb
@@ -29,8 +29,8 @@ module Gitlab
       alias_method :repo, :raw
 
       def initialize(path_with_namespace, root_ref)
-        @root_ref = root_ref || raw.head.name
         @path_with_namespace = path_with_namespace
+        @root_ref = root_ref || raw.head.name
 
         # Init grit repo object
         raw


### PR DESCRIPTION
rotated two lines in lib/gitlab_git/repository.rb
the method `raw` needs @path_with_namespace,
so `raw.head.name` should not be executed before `@path_with_namespace = path_with_namespace`
