### PR TITLE
Correct initializer

### DIFF
--- a/lib/gitlab_git/repository.rb
+++ b/lib/gitlab_git/repository.rb
@@ -29,8 +29,8 @@ module Gitlab
       alias_method :repo, :raw
 
       def initialize(path_with_namespace, root_ref)
-        @root_ref = root_ref || raw.head.name
         @path_with_namespace = path_with_namespace
+        @root_ref = root_ref || raw.head.name
 
         # Init grit repo object
         raw


### PR DESCRIPTION
Fix error while create repo instance without default branch

``` ruby
Gitlab::Git::Repository.new(project.path_with_namespace, project.default_branch)
```

where `project.default_branch` is `nil` for new repository

```
1.9.3 :022 > Gitlab::Git::Repository.new(pr.path_with_namespace, nil)
Gitlab::Git::Repository::NoRepository: no repository for such path
    from /rest/u/apps/gitlab/shared/bundle/ruby/1.9.1/gems/gitlab_git-2.2.0/lib/gitlab_git/repository.rb:50:in `rescue in raw'
    from /rest/u/apps/gitlab/shared/bundle/ruby/1.9.1/gems/gitlab_git-2.2.0/lib/gitlab_git/repository.rb:48:in `raw'
    from /rest/u/apps/gitlab/shared/bundle/ruby/1.9.1/gems/gitlab_git-2.2.0/lib/gitlab_git/repository.rb:32:in `initialize'
    from (irb):22:in `new'
    from (irb):22
    from /rest/u/apps/gitlab/shared/bundle/ruby/1.9.1/gems/railties-3.2.13/lib/rails/commands/console.rb:47:in `start'
    from /rest/u/apps/gitlab/shared/bundle/ruby/1.9.1/gems/railties-3.2.13/lib/rails/commands/console.rb:8:in `start'
    from /rest/u/apps/gitlab/shared/bundle/ruby/1.9.1/gems/railties-3.2.13/lib/rails/commands.rb:41:in `<top (required)>'
    from script/rails:6:in `require'
    from script/rails:6:in `<main>'
```
