### PR TITLE
require 'active_support/core_ext/object/try'

### DIFF
--- a/lib/gitlab_git.rb
+++ b/lib/gitlab_git.rb
@@ -4,6 +4,7 @@ require 'fileutils'
 require 'grit'
 require 'linguist'
 require 'active_support/core_ext/hash/keys'
+require 'active_support/core_ext/object/try'
 require 'grit'
 require 'grit_ext'
 


### PR DESCRIPTION
To solve the problem that the `NoMethodError` when you read this by itself

``` ruby:test.rb
require "gitlab_git"

repo_gitlab = Gitlab::Git::Repository.new('gitlab')

compare = Gitlab::Git::Compare.new(repo_gitlab, 'v6.0.0', 'master')
```

Error:

``````
gitlab_git/lib/gitlab_git/compare.rb:15:in `initialize': undefined method `try' for "v6.0.0":String (NoMethodError)
    from test.rb:5:in `new'
    from test.rb:5:in `<main>'```
``````
