### PR TITLE
Fix branch name encoding issue

### DIFF
--- a/lib/gitlab_git/repository.rb
+++ b/lib/gitlab_git/repository.rb
@@ -1,6 +1,8 @@
 # Gitlab::Git::Commit is a wrapper around native Grit::Repository object
 # We dont want to use grit objects inside app/
 # It helps us easily migrate to rugged in future
+require_relative 'encoding_herlper'
+
 module Gitlab
   module Git
     class Repository
@@ -297,11 +299,7 @@ module Gitlab
         output = grit.git.native(:branch, {contains: true}, commit)
 
         # Fix encoding issue
-        locale = Encoding::locale_charmap
-        if locale.nil?
-            locale = Encoding::UTF_8
-        end
-        output.force_encoding(locale).encode!(Encoding::UTF_8)
+        output = EncodingHelper::encode!(output)
 
         # The output is expected as follow
         #   fix-aaa


### PR DESCRIPTION
When the branch name contains non-ascii characters, it will raise a encoding error when viewing any commit of this branch.

Here is the detail of traceback.

```
Encoding::CompatibilityError (incompatible character encodings: UTF-8 and ASCII-8BIT):
  app/views/projects/commit/_commit_box.html.haml:47:in `_app_views_projects_commit__commit_box_html_haml__3615852107586763187_70120827707580'
  app/views/projects/commit/show.html.haml:1:in `_app_views_projects_commit_show_html_haml___1131168359666268760_70120827597420'
  app/controllers/application_controller.rb:57:in `set_current_user_for_thread'

  Rendered errors/encoding.html.haml within layouts/errors (0.1ms)
  Rendered layouts/_head.html.haml (1.4ms)
  Rendered layouts/_search.html.haml (1.4ms)
  Rendered layouts/_head_panel.html.haml (10.0ms)
  Rendered layouts/_flash.html.haml (0.2ms)
Completed 500 Internal Server Error in 526ms (Views: 12.4ms | ActiveRecord: 14.5ms)
```
