### PR TITLE
Branches from rugged repository method

### DIFF
--- a/lib/gitlab_git/repository.rb
+++ b/lib/gitlab_git/repository.rb
@@ -56,9 +56,7 @@ module Gitlab
 
       # Returns an Array of Branches
       def branches
-        rugged.refs.select do |ref|
-          ref.name =~ /\Arefs\/heads/
-        end.map do |rugged_ref|
+        rugged.branches.map do |rugged_ref|
           Branch.new(rugged_ref.name, rugged_ref.target)
         end.sort_by(&:name)
       end


### PR DESCRIPTION
Migrate to Rugged::Repository branches method http://rubydoc.info/gems/rugged/Rugged/Repository#branches-instance_method
