### PR TITLE
Tags via Rugged::Repository.tags method

### DIFF
--- a/lib/gitlab_git/repository.rb
+++ b/lib/gitlab_git/repository.rb
@@ -70,9 +70,7 @@ module Gitlab
 
       # Returns an Array of Tags
       def tags
-        rugged.refs.select do |ref|
-          ref.name =~ /\Arefs\/tags/
-        end.map do |rugged_ref|
+        rugged.tags.map do |rugged_ref|
           Tag.new(rugged_ref.name, rugged_ref.target)
         end.sort_by(&:name)
       end


### PR DESCRIPTION
Use Rugged::Repository.tags method instead parse all refs: http://rubydoc.info/gems/rugged/Rugged/Repository#tags-instance_method
