### PR TITLE
gzip archive - do not save the  original  file  name  and  timestamp  by default. Fix #32

### DIFF
--- a/lib/gitlab_git/repository.rb
+++ b/lib/gitlab_git/repository.rb
@@ -153,7 +153,7 @@ module Gitlab
           # everything else should fall back to tar.gz
           extension = ".tar.gz"
           git_archive_format = nil
-          pipe_cmd = "gzip"
+          pipe_cmd = "gzip -n"
         end
 
         # Build file path


### PR DESCRIPTION
All info in https://github.com/gitlabhq/gitlabhq/issues/6662
