### PR TITLE
Use git log --follow to get commits collection. Closes #6966 of gitlabhq/gitlabhq

### DIFF
--- a/lib/gitlab_git/commit.rb
+++ b/lib/gitlab_git/commit.rb
@@ -26,10 +26,9 @@ module Gitlab
         #   )
         #
         def where(options)
-          default_options = {
-            follow: options[:path].present?
-          }
-          options = default_options.merge(options)
+          if options.has_key?(:path) and options[:path].present?
+            options[:follow] = true
+          end
 
           repo = options.delete(:repo)
           raise 'Gitlab::Git::Repository is required' unless repo.respond_to?(:log)


### PR DESCRIPTION
Based on pull request #3502 from akzhan.
