### PR TITLE
Hound prefer single quotes.

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,3 @@
+StringLiterals:
+  EnforcedStyle: single_quotes
+  Enabled: true


### PR DESCRIPTION
It's barking: https://github.com/gitlabhq/gitlab_git/pull/43#discussion-diff-17520021

Same was done for GitLab.
