### PR TITLE
Improve Repository#branches_contains performance

### DIFF
--- a/lib/gitlab_git/repository.rb
+++ b/lib/gitlab_git/repository.rb
@@ -339,13 +339,15 @@ module Gitlab
       #   repo.branch_names_contains('master')
       #
       def branches_contains(commit)
-        sha = rugged.rev_parse_oid(commit)
+        commit_obj = rugged.rev_parse(commit)
+        parent = commit_obj.parents.first unless commit_obj.parents.empty?
 
         walker = Rugged::Walker.new(rugged)
 
         rugged.branches.select do |branch|
           walker.push(branch.target_id)
-          result = walker.any? { |c| c.oid == sha }
+          walker.hide(parent) if parent
+          result = walker.any? { |c| c.oid == commit_obj.oid }
           walker.reset
 
           result


### PR DESCRIPTION
I saw that GitLab CE stopped using `Repository#branches_contains` in favor of a native git call via `GitLab::Popen` because of poor performance in the former (https://github.com/gitlabhq/gitlabhq/commit/88b1e0ffcd27ab3d9ff9ce1fe5b493e3f6296b21).  This change closes the performance gap, although native git still wins in most cases.  I wrote a simple [test](https://gist.github.com/mr-vinn/df861fcb9c5be2f34c67) that compares the two approaches for various points in the commit history; here are the results using the GitLab CE repo:
### Old

```
[1] pry(main)> require_relative 'branch-contains-benchmark.rb'
=> true
[2] pry(main)> run_benchmark

*** Revspec = master~0; commit ID = 60f4eb55ca9b8e33a97e612a8b5744496197871c ***
       user     system      total        real
native  0.000000   0.000000   0.040000 (  0.054517)
rugged  1.230000   0.080000   1.310000 (  1.310889)

*** Revspec = master~500; commit ID = 0f080a94106904c57cfcb6c1d02c6207c1d4617e ***
       user     system      total        real
native  0.010000   0.000000   0.080000 (  0.065255)
rugged  1.040000   0.060000   1.100000 (  1.098989)

*** Revspec = master~1000; commit ID = 11aa7b00251d8fd29bb7f8c5a6176eb9713ff3ae ***
       user     system      total        real
native  0.000000   0.000000   0.060000 (  0.064635)
rugged  1.100000   0.070000   1.170000 (  1.172561)

*** Revspec = master~1500; commit ID = 0e387919c3827260434aed48e1f28ee02ce5e58d ***
       user     system      total        real
native  0.000000   0.000000   0.080000 (  0.088946)
rugged  0.910000   0.050000   0.960000 (  0.966598)

*** Revspec = master~2000; commit ID = 0a4a6f5921b256feabc2a1c95db2346254914efc ***
       user     system      total        real
native  0.000000   0.000000   0.080000 (  0.088354)
rugged  0.750000   0.050000   0.800000 (  0.798368)

*** Revspec = master~2500; commit ID = 86da625f1dc99ef57e554f1c39cb0db20f45a5b6 ***
       user     system      total        real
native  0.000000   0.000000   0.110000 (  0.110350)
rugged  0.710000   0.050000   0.760000 (  0.762672)

*** Revspec = master~3000; commit ID = 8fe58ed541e04f81de8e401c17d021aa4092a526 ***
       user     system      total        real
native  0.000000   0.000000   0.110000 (  0.103423)
rugged  0.130000   0.020000   0.150000 (  0.146589)

*** Revspec = master~3500; commit ID = 64f026b254a9492bc22cdbad45ceb4743949f406 ***
       user     system      total        real
native  0.000000   0.000000   0.120000 (  0.119624)
rugged  0.520000   0.040000   0.560000 (  0.568392)

*** Revspec = master~4000; commit ID = 8d02d8c0456aa3307ed9074ac1944df7b2c19eb2 ***
       user     system      total        real
native  0.000000   0.000000   0.100000 (  0.110349)
rugged  0.290000   0.020000   0.310000 (  0.310607)
```
### New

```
[1] pry(main)> require_relative 'branch-contains-benchmark.rb'
=> true
[2] pry(main)> run_benchmark

*** Revspec = master~0; commit ID = 60f4eb55ca9b8e33a97e612a8b5744496197871c ***
       user     system      total        real
native  0.000000   0.000000   0.050000 (  0.057332)
rugged  0.260000   0.030000   0.290000 (  0.298045)

*** Revspec = master~500; commit ID = 0f080a94106904c57cfcb6c1d02c6207c1d4617e ***
       user     system      total        real
native  0.000000   0.010000   0.070000 (  0.064159)
rugged  0.050000   0.000000   0.050000 (  0.058972)

*** Revspec = master~1000; commit ID = 11aa7b00251d8fd29bb7f8c5a6176eb9713ff3ae ***
       user     system      total        real
native  0.010000   0.000000   0.070000 (  0.063287)
rugged  0.060000   0.010000   0.070000 (  0.068386)

*** Revspec = master~1500; commit ID = 0e387919c3827260434aed48e1f28ee02ce5e58d ***
       user     system      total        real
native  0.000000   0.000000   0.080000 (  0.087986)
rugged  0.080000   0.010000   0.090000 (  0.086852)

*** Revspec = master~2000; commit ID = 0a4a6f5921b256feabc2a1c95db2346254914efc ***
       user     system      total        real
native  0.000000   0.010000   0.100000 (  0.088411)
rugged  0.070000   0.000000   0.070000 (  0.081607)

*** Revspec = master~2500; commit ID = 86da625f1dc99ef57e554f1c39cb0db20f45a5b6 ***
       user     system      total        real
native  0.000000   0.010000   0.120000 (  0.107933)
rugged  0.100000   0.010000   0.110000 (  0.123823)

*** Revspec = master~3000; commit ID = 8fe58ed541e04f81de8e401c17d021aa4092a526 ***
       user     system      total        real
native  0.000000   0.000000   0.100000 (  0.111005)
rugged  0.160000   0.020000   0.180000 (  0.181757)

*** Revspec = master~3500; commit ID = 64f026b254a9492bc22cdbad45ceb4743949f406 ***
       user     system      total        real
native  0.000000   0.000000   0.100000 (  0.104057)
rugged  0.180000   0.020000   0.200000 (  0.198139)

*** Revspec = master~4000; commit ID = 8d02d8c0456aa3307ed9074ac1944df7b2c19eb2 ***
       user     system      total        real
native  0.000000   0.000000   0.120000 (  0.115354)
rugged  0.210000   0.020000   0.230000 (  0.229930)
```
