### PR TITLE
Add new method to Gitlab::Git::Repository

### DIFF
--- a/lib/gitlab_git/repository.rb
+++ b/lib/gitlab_git/repository.rb
@@ -704,6 +704,11 @@ module Gitlab
         commits
       end
 
+      # Set the "core.autocrlf" config option to true for this repo.
+      def enable_autocrlf
+        rugged.config['core.autocrlf'] = true
+      end
+
       private
 
       # Return the object that +revspec+ points to.  If +revspec+ is an

--- a/spec/repository_spec.rb
+++ b/spec/repository_spec.rb
@@ -539,4 +539,22 @@ describe Gitlab::Git::Repository do
     it { should_not include('feature') }
     it { should_not include('fix') }
   end
+
+  describe '#enable_autocrlf' do
+    before(:all) do
+      @repo = Gitlab::Git::Repository.new(TEST_MUTABLE_REPO_PATH)
+      @repo.rugged.config['core.autocrlf'] = false
+    end
+
+    it 'should set the autocrlf option to true' do
+      @repo.enable_autocrlf
+      File.open(File.join(TEST_MUTABLE_REPO_PATH, '.git', 'config')) do |config_file|
+        expect(config_file.read).to match('autocrlf = true')
+      end
+    end
+
+    after(:all) do
+      @repo.rugged.delete('core.autocrlf')
+    end
+  end
 end


### PR DESCRIPTION
Add a new convenience method, `#enable_autocrlf`, to the Repository class.  The new method sets the `core.autocrlf` config option to true for a repo.  This can be used by GitLab in satellite repos to handle the `\r\n` line endings that get written when editing via the web interface.  This is part of the fix for gitlabhq/gitlabhq#7950.
