### PR TITLE
Ensure that we don't have dupes in branches list

### DIFF
--- a/lib/gitlab_git/repository.rb
+++ b/lib/gitlab_git/repository.rb
@@ -47,13 +47,15 @@ module Gitlab
       # Returns an Array of branch names
       # sorted by name ASC
       def branch_names
-        branches.map(&:name)
+        branches.uniq.map(&:name)
       end
 
       # Returns an Array of Branches
       def branches
         rugged.branches.map do |rugged_ref|
           Branch.new(rugged_ref.name, rugged_ref.target)
+        end.uniq do |branch|
+          branch.name
         end.sort_by(&:name)
       end
 


### PR DESCRIPTION
After converting an SVN repo to Git and importing it into GitLab a few of the branches were duped in the branches list. Doing `git branch -a` showed that my repo didn't have any duped branches so it seemed like the issue was in GitLab somewhere. Adding the `uniq` check solved the issue for me.

As a note: GitLab v6.9 didn't have any branch dupes. v7.0+ did.
