### PR TITLE
Added function ls_files in Gitlab::Git::Repository

### DIFF
--- a/lib/gitlab_git/repository.rb
+++ b/lib/gitlab_git/repository.rb
@@ -807,6 +807,32 @@ module Gitlab
         rugged.config['core.autocrlf'] = AUTOCRLF_VALUES.invert[value]
       end
 
+      # Return result like "git ls-files" , recursive and full file path only
+      #
+      # Ex.
+      #   repo.ls_files('master')
+      #
+      def ls_files(ref)
+        actual_ref = ref || root_ref
+
+        begin
+          sha = sha_from_ref(actual_ref)
+        rescue Rugged::OdbError, Rugged::InvalidError, Rugged::ReferenceError
+          # Return an empty array if the ref wasn't found
+          return []
+        end
+
+        cmd = %W(git --git-dir=#{path} ls-tree)
+        cmd += %W(-r)
+        cmd += %W(--full-tree)
+        cmd += %W(--full-name)
+        cmd += %W(--name-only)
+        cmd += %W(-- #{actual_ref})
+        raw_output = IO.popen(cmd) {|io| io.read }
+
+        raw_output.split("\n")
+      end
+
       private
 
       # Get the content of a blob for a given commit.  If the blob is a commit


### PR DESCRIPTION
Using native git command(git ls-tree), I make simple function.
ls_files function ls to return only each file's full paths of a repository

This function is called by ```Repository``` within GitLab as @DouweM 's suggestion.
(ref : https://github.com/gitlabhq/gitlabhq/pull/9889 & https://github.com/gitlabhq/gitlabhq/pull/9855)